### PR TITLE
Fix mobile edits never syncing back to the opened (cloud) file

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 
 ### Improvements
 
+- Mobile: new plans now ask where to save — pick a folder like iCloud Drive and the plan file stays updated automatically as you edit (replacing the manual "Export / Back Up Plan" step). Plans kept on-device can be saved to a folder later from Settings.
 - Mobile: Search now lives in the tab bar (replacing the floating button), and closing a plan moved into Settings for a cleaner header.
 - Mobile: set your first paycheck date so weekly/bi-weekly paychecks-per-month match desktop.
 - Mobile: removed the redundant per-account "Monthly Allocation" field in favor of Custom Allocations.
@@ -26,4 +27,5 @@
 ### Bug Fixes
 
 - Mobile: edits now save back to the file you opened — including cloud documents (iCloud Drive, Google Drive, etc.) — instead of only to a device-local copy. Reopening a plan from Recent Files also picks up changes made on desktop, and Settings shows whether the original file is in sync.
+- Mobile: fixed the header back button not responding (e.g. when leaving Settings) on iOS 26.
 - Account icons created on mobile now use names desktop can render (previously stored an incompatible value).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,4 +25,5 @@
 
 ### Bug Fixes
 
+- Mobile: edits now save back to the file you opened — including cloud documents (iCloud Drive, Google Drive, etc.) — instead of only to a device-local copy. Reopening a plan from Recent Files also picks up changes made on desktop, and Settings shows whether the original file is in sync.
 - Account icons created on mobile now use names desktop can render (previously stored an incompatible value).

--- a/apps/mobile/__tests__/planFileAdapter.test.ts
+++ b/apps/mobile/__tests__/planFileAdapter.test.ts
@@ -12,8 +12,31 @@ vi.mock('expo-file-system/legacy', () => ({
   EncodingType: { UTF8: 'utf8' },
 }));
 
+// Mock the non-legacy File API used for writing back to the source document.
+const fileWriteMock = vi.fn();
+const fileCtorUris: string[] = [];
+vi.mock('expo-file-system', () => ({
+  File: class {
+    uri: string;
+    constructor(uri: string) {
+      this.uri = uri;
+      fileCtorUris.push(uri);
+    }
+    write(content: string | Uint8Array) {
+      fileWriteMock(this.uri, content);
+    }
+  },
+}));
+
 import * as FileSystem from 'expo-file-system/legacy';
-import { readPlanFile, decryptPlan, serializePlan, writePlanFile } from '../src/storage/planFileAdapter';
+import {
+  readPlanFile,
+  decryptPlan,
+  serializePlan,
+  writePlanFile,
+  writePlanToSource,
+  copyPlanIntoLibrary,
+} from '../src/storage/planFileAdapter';
 
 const MOCK_PLAN = {
   id: 'test-plan-001',
@@ -157,5 +180,60 @@ describe('writePlanFile', () => {
       serializePlan(MOCK_PLAN as never),
       { encoding: 'utf8' },
     );
+  });
+});
+
+describe('writePlanToSource', () => {
+  beforeEach(() => {
+    fileWriteMock.mockReset();
+    fileCtorUris.length = 0;
+  });
+
+  it('writes plain JSON back to the original document uri', async () => {
+    const sourceUri = 'content://com.provider.cloud/document/plan%2Ebudget';
+    await writePlanToSource(sourceUri, MOCK_PLAN as never);
+    expect(fileWriteMock).toHaveBeenCalledWith(sourceUri, serializePlan(MOCK_PLAN as never));
+  });
+
+  it('writes the encrypted envelope when a key is given', async () => {
+    await writePlanToSource('file:///icloud/plan.budget', MOCK_PLAN as never, 'the-key');
+    const [, content] = fileWriteMock.mock.calls[0];
+    const envelope = JSON.parse(content as string);
+    expect(envelope.format).toBe('paycheck-planner-encrypted-v1');
+    expect(decryptPlan(envelope.payload, 'the-key')?.id).toBe('test-plan-001');
+  });
+
+  it('propagates write failures so callers can surface a sync error', async () => {
+    fileWriteMock.mockImplementation(() => {
+      throw new Error('Permission lapsed');
+    });
+    await expect(
+      writePlanToSource('content://gone/doc', MOCK_PLAN as never),
+    ).rejects.toThrow('Permission lapsed');
+  });
+});
+
+describe('copyPlanIntoLibrary', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('copies the picked document into the plans library and returns the durable uri', async () => {
+    vi.mocked(FileSystem.getInfoAsync).mockResolvedValue({ exists: true } as never);
+    vi.mocked(FileSystem.copyAsync).mockResolvedValue();
+    const uri = await copyPlanIntoLibrary('content://picker/doc%2Fplan', 'test-plan-001');
+    expect(uri).toBe('file:///documents/plans/test-plan-001.budget');
+    expect(FileSystem.copyAsync).toHaveBeenCalledWith({
+      from: 'content://picker/doc%2Fplan',
+      to: 'file:///documents/plans/test-plan-001.budget',
+    });
+  });
+
+  it('does not copy onto itself when the source already is the library file', async () => {
+    vi.mocked(FileSystem.getInfoAsync).mockResolvedValue({ exists: true } as never);
+    const libraryUri = 'file:///documents/plans/test-plan-001.budget';
+    const uri = await copyPlanIntoLibrary(libraryUri, 'test-plan-001');
+    expect(uri).toBe(libraryUri);
+    expect(FileSystem.copyAsync).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/__tests__/planFileAdapter.test.ts
+++ b/apps/mobile/__tests__/planFileAdapter.test.ts
@@ -12,20 +12,45 @@ vi.mock('expo-file-system/legacy', () => ({
   EncodingType: { UTF8: 'utf8' },
 }));
 
-// Mock the non-legacy File API used for writing back to the source document.
-const fileWriteMock = vi.fn();
-const fileCtorUris: string[] = [];
+// Mock the non-legacy File API used for writing back to the source document
+// and creating plan files in a user-picked folder. vi.mock factories are
+// hoisted above this file's body, so the shared state lives in vi.hoisted.
+const { fileWriteMock, pickDirectoryAsyncMock, createFileMock, MockFile, MockDirectory } =
+  vi.hoisted(() => {
+    const fileWriteMock = vi.fn();
+    const pickDirectoryAsyncMock = vi.fn();
+    const createFileMock = vi.fn();
+
+    class MockFile {
+      uri: string;
+      constructor(uri: string) {
+        this.uri = uri;
+      }
+      write(content: string | Uint8Array) {
+        fileWriteMock(this.uri, content);
+      }
+    }
+
+    class MockDirectory {
+      uri: string;
+      constructor(uri: string) {
+        this.uri = uri;
+      }
+      static pickDirectoryAsync(...args: unknown[]) {
+        return pickDirectoryAsyncMock(...args);
+      }
+      createFile(name: string, mimeType: string | null): MockFile {
+        createFileMock(this.uri, name, mimeType);
+        return new MockFile(`${this.uri}/${encodeURIComponent(name)}`);
+      }
+    }
+
+    return { fileWriteMock, pickDirectoryAsyncMock, createFileMock, MockFile, MockDirectory };
+  });
+
 vi.mock('expo-file-system', () => ({
-  File: class {
-    uri: string;
-    constructor(uri: string) {
-      this.uri = uri;
-      fileCtorUris.push(uri);
-    }
-    write(content: string | Uint8Array) {
-      fileWriteMock(this.uri, content);
-    }
-  },
+  File: MockFile,
+  Directory: MockDirectory,
 }));
 
 import * as FileSystem from 'expo-file-system/legacy';
@@ -36,6 +61,7 @@ import {
   writePlanFile,
   writePlanToSource,
   copyPlanIntoLibrary,
+  createPlanFileInFolder,
 } from '../src/storage/planFileAdapter';
 
 const MOCK_PLAN = {
@@ -186,7 +212,6 @@ describe('writePlanFile', () => {
 describe('writePlanToSource', () => {
   beforeEach(() => {
     fileWriteMock.mockReset();
-    fileCtorUris.length = 0;
   });
 
   it('writes plain JSON back to the original document uri', async () => {
@@ -210,6 +235,56 @@ describe('writePlanToSource', () => {
     await expect(
       writePlanToSource('content://gone/doc', MOCK_PLAN as never),
     ).rejects.toThrow('Permission lapsed');
+  });
+});
+
+describe('createPlanFileInFolder', () => {
+  beforeEach(() => {
+    pickDirectoryAsyncMock.mockReset();
+    createFileMock.mockReset();
+    fileWriteMock.mockReset();
+  });
+
+  it('creates a plan-named .budget document in the picked folder and writes the plan', async () => {
+    pickDirectoryAsyncMock.mockResolvedValue(new MockDirectory('content://tree/icloud-docs'));
+    const result = await createPlanFileInFolder(MOCK_PLAN as never);
+
+    expect(result.status).toBe('created');
+    expect(createFileMock).toHaveBeenCalledWith(
+      'content://tree/icloud-docs',
+      'Test Plan.budget',
+      'application/json',
+    );
+    if (result.status === 'created') {
+      expect(fileWriteMock).toHaveBeenCalledWith(result.uri, serializePlan(MOCK_PLAN as never));
+    }
+  });
+
+  it('writes the encrypted envelope when a key is given', async () => {
+    pickDirectoryAsyncMock.mockResolvedValue(new MockDirectory('file:///chosen-dir'));
+    await createPlanFileInFolder(MOCK_PLAN as never, 'folder-key');
+    const [, content] = fileWriteMock.mock.calls[0];
+    const envelope = JSON.parse(content as string);
+    expect(envelope.format).toBe('paycheck-planner-encrypted-v1');
+    expect(decryptPlan(envelope.payload, 'folder-key')?.id).toBe('test-plan-001');
+  });
+
+  it('returns canceled when the user dismisses the folder picker', async () => {
+    pickDirectoryAsyncMock.mockRejectedValue(
+      Object.assign(new Error('The file picker was cancelled by the user'), {
+        code: 'ERR_PICKER_CANCELLED',
+      }),
+    );
+    const result = await createPlanFileInFolder(MOCK_PLAN as never);
+    expect(result).toEqual({ status: 'canceled' });
+    expect(createFileMock).not.toHaveBeenCalled();
+  });
+
+  it('rethrows real picker failures so the UI can show them', async () => {
+    pickDirectoryAsyncMock.mockRejectedValue(new Error('Provider unavailable'));
+    await expect(createPlanFileInFolder(MOCK_PLAN as never)).rejects.toThrow(
+      'Provider unavailable',
+    );
   });
 });
 

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -17,7 +17,7 @@ import { generateDemoBudgetData, type BudgetData } from '@paycheck-planner/core'
 import { usePlanFile } from '../src/hooks/usePlanFile';
 import { usePlan } from '../src/contexts/PlanContext';
 import { getRecentFiles, removeRecentFile, type RecentFile } from '../src/storage/recentFilesStore';
-import { readPlanFile, decryptPlan } from '../src/storage/planFileAdapter';
+import { readPlanFile, decryptPlan, copyPlanIntoLibrary } from '../src/storage/planFileAdapter';
 import { getStoredPlanKey } from '../src/storage/keychainAdapter';
 import { useTheme } from '../src/contexts/ThemeContext';
 import { ThemedText } from '../src/components/ThemedText';
@@ -32,8 +32,8 @@ export default function WelcomeScreen() {
   const [keyError, setKeyError] = useState<string | null>(null);
 
   const onPlanLoaded = useCallback(
-    (plan: BudgetData, uri: string, encryptionKey: string | null) => {
-      setPlan(plan, uri, { encryptionKey });
+    (plan: BudgetData, uri: string, encryptionKey: string | null, sourceUri: string | null) => {
+      setPlan(plan, uri, { encryptionKey, sourceUri });
       router.replace('/(tabs)/summary');
     },
     [setPlan],
@@ -64,11 +64,29 @@ export default function WelcomeScreen() {
   }
 
   async function openRecentFile(file: RecentFile) {
-    const parsed = await readPlanFile(file.uri);
-    if (parsed.status === 'invalid') return;
+    // Prefer the original document so edits made elsewhere (e.g. on desktop via
+    // cloud sync) are picked up; fall back to the on-device copy when the source
+    // is unreachable (access lapsed after a restart, file moved or deleted).
+    let sourceUri = file.sourceUri ?? null;
+    let parsed = sourceUri ? await readPlanFile(sourceUri) : null;
+    if (!parsed || parsed.status === 'invalid') {
+      sourceUri = null;
+      parsed = await readPlanFile(file.uri);
+      if (parsed.status === 'invalid') return;
+    }
+
+    // The source was readable — refresh the on-device working copy from it.
+    let workingUri = file.uri;
+    if (sourceUri) {
+      try {
+        workingUri = await copyPlanIntoLibrary(sourceUri, parsed.planId);
+      } catch {
+        // Keep the existing copy; saves will still sync back to the source.
+      }
+    }
 
     if (parsed.status === 'ok') {
-      setPlan(parsed.data, file.uri);
+      setPlan(parsed.data, workingUri, { sourceUri });
       router.replace('/(tabs)/summary');
       return;
     }
@@ -78,7 +96,7 @@ export default function WelcomeScreen() {
     if (storedKey) {
       const plan = decryptPlan(parsed.payload, storedKey);
       if (plan) {
-        setPlan(plan, file.uri, { encryptionKey: storedKey });
+        setPlan(plan, workingUri, { encryptionKey: storedKey, sourceUri });
         router.replace('/(tabs)/summary');
         return;
       }

--- a/apps/mobile/app/new-plan.tsx
+++ b/apps/mobile/app/new-plan.tsx
@@ -13,7 +13,7 @@ import {
 import { usePlan } from '../src/contexts/PlanContext';
 import { useTheme } from '../src/contexts/ThemeContext';
 import { createEmptyPlan } from '../src/utils/createPlan';
-import { createPlanFileInLibrary } from '../src/storage/planFileAdapter';
+import { createPlanFileInLibrary, createPlanFileInFolder } from '../src/storage/planFileAdapter';
 import { addRecentFile } from '../src/storage/recentFilesStore';
 import { storePlanKey } from '../src/storage/keychainAdapter';
 import { ThemedView } from '../src/components/ThemedView';
@@ -38,6 +38,13 @@ const CURRENCY_OPTIONS = CURRENCIES.map((currency) => ({
   label: `${currency.symbol} ${currency.code}`,
 }));
 
+type SaveLocation = 'folder' | 'device';
+
+const SAVE_LOCATION_OPTIONS: { value: SaveLocation; label: string }[] = [
+  { value: 'folder', label: 'Files / iCloud folder…' },
+  { value: 'device', label: 'On this device only' },
+];
+
 export default function NewPlanScreen() {
   const { setPlan } = usePlan();
   const { colors, spacing, radius } = useTheme();
@@ -51,6 +58,7 @@ export default function NewPlanScreen() {
   const [hourlyRate, setHourlyRate] = useState('');
   const [hoursPerPayPeriod, setHoursPerPayPeriod] = useState('');
   const [payFrequency, setPayFrequency] = useState<PayFrequency>('bi-weekly');
+  const [saveLocation, setSaveLocation] = useState<SaveLocation>('folder');
   const [encrypt, setEncrypt] = useState(false);
   const [encryptionKey, setEncryptionKey] = useState('');
   const [confirmKey, setConfirmKey] = useState('');
@@ -102,6 +110,18 @@ export default function NewPlanScreen() {
       });
 
       const key = encrypt ? trimmedKey : null;
+
+      // Create the user-visible document first when a folder was requested, so
+      // cancelling the folder picker leaves nothing behind and stays in the wizard.
+      let sourceUri: string | null = null;
+      if (saveLocation === 'folder') {
+        const result = await createPlanFileInFolder(plan, key);
+        if (result.status === 'canceled') return;
+        sourceUri = result.uri;
+      }
+
+      // The durable working copy lives in the app's storage; edits auto-save
+      // there and are mirrored to the folder document when one was chosen.
       const uri = await createPlanFileInLibrary(plan, key);
       await addRecentFile({
         uri,
@@ -110,13 +130,14 @@ export default function NewPlanScreen() {
         planId: plan.id,
         planName: plan.name,
         planYear: plan.year,
+        ...(sourceUri ? { sourceUri } : {}),
       });
 
       // Remember the key (biometric-protected when available) so the plan
       // reopens without re-entry; best-effort and never blocks creation.
       if (key) await storePlanKey(plan.id, key);
 
-      setPlan(plan, uri, { encryptionKey: key });
+      setPlan(plan, uri, { encryptionKey: key, sourceUri });
       router.replace('/(tabs)/summary');
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -162,6 +183,20 @@ export default function NewPlanScreen() {
             value={currency}
             onChange={setCurrency}
           />
+        </SectionCard>
+
+        <SectionCard title="Save Location">
+          <OptionPicker
+            label="Save the plan file"
+            options={SAVE_LOCATION_OPTIONS}
+            value={saveLocation}
+            onChange={setSaveLocation}
+          />
+          <ThemedText variant="tertiary" size="xs">
+            {saveLocation === 'folder'
+              ? 'You’ll pick a folder (like iCloud Drive) when the plan is created. The file stays in sync as you edit, and desktop can open it too.'
+              : 'The plan is stored privately inside the app on this phone. You can move it to a folder later from Settings.'}
+          </ThemedText>
         </SectionCard>
 
         <SectionCard title="Pay">
@@ -288,9 +323,9 @@ export default function NewPlanScreen() {
             </ThemedText>
           </View>
           <ThemedText variant="secondary" size="xs" style={{ marginTop: spacing.xs, lineHeight: 18 }}>
-            Your plan is saved automatically on this device and edits keep saving as you go. To back
-            it up or move it elsewhere, use Settings → “Export / Back Up Plan”, which lets you save a
-            copy to Files, iCloud, or share it to the desktop app.
+            Your plan saves automatically as you edit — there’s no save button. A working copy
+            always lives safely on this device, and if you choose a folder above, the plan file
+            there is kept up to date too, so it’s backed up and shared with the desktop app.
           </ThemedText>
         </View>
       </ScrollView>

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ScrollView, View, TouchableOpacity, Alert, StyleSheet } from 'react-native';
 import { router, Stack } from 'expo-router';
-import * as Sharing from 'expo-sharing';
 import Constants from 'expo-constants';
 import { Feather } from '@expo/vector-icons';
 import { usePlan } from '../src/contexts/PlanContext';
@@ -15,7 +14,8 @@ import {
   storePlanKey,
   type BiometricType,
 } from '../src/storage/keychainAdapter';
-import { createShareableCopy } from '../src/storage/planFileAdapter';
+import { createPlanFileInFolder } from '../src/storage/planFileAdapter';
+import { addRecentFile } from '../src/storage/recentFilesStore';
 import { ThemedView } from '../src/components/ThemedView';
 import { ThemedText } from '../src/components/ThemedText';
 import { MetricRow } from '../src/components/MetricRow';
@@ -40,10 +40,10 @@ const MODE_OPTIONS: { value: ThemeMode; label: string }[] = [
 ];
 
 export default function SettingsScreen() {
-  const { plan, sourcePath, sourceUri, encryptionKey, saveState, saveError, syncState, syncError, canUndo, canRedo, undo, redo, closePlan, changeEncryptionKey } =
+  const { plan, sourcePath, sourceUri, encryptionKey, saveState, saveError, syncState, syncError, canUndo, canRedo, undo, redo, closePlan, changeEncryptionKey, attachSource } =
     usePlan();
   const { colors, spacing, radius, isDark, mode, preset, setMode, setPreset } = useTheme();
-  const [sharing, setSharing] = useState(false);
+  const [linkingFolder, setLinkingFolder] = useState(false);
   const [biometricType, setBiometricType] = useState<BiometricType>('none');
   const [biometricEnabled, setBiometricEnabled] = useState(false);
   const [biometricBusy, setBiometricBusy] = useState(false);
@@ -129,22 +129,32 @@ export default function SettingsScreen() {
     );
   }
 
-  async function sharePlanFile() {
+  // Create the plan's document in a user-chosen folder (Files/iCloud/Drive) and
+  // link it as the plan's source, so every save lands there from now on.
+  async function saveToFolder() {
     if (!sourcePath || !plan) return;
-    setSharing(true);
+    setLinkingFolder(true);
     try {
-      if (await Sharing.isAvailableAsync()) {
-        // Share a copy named after the plan (e.g. "2026 Plan.budget") rather
-        // than the internal UUID file, matching the desktop's saved filenames.
-        const shareUri = await createShareableCopy(sourcePath, plan);
-        await Sharing.shareAsync(shareUri, {
-          mimeType: 'application/json',
-          dialogTitle: 'Export or back up budget plan',
-          UTI: 'public.json',
-        });
-      }
+      const result = await createPlanFileInFolder(plan, encryptionKey);
+      if (result.status === 'canceled') return;
+
+      attachSource(result.uri);
+      await addRecentFile({
+        uri: sourcePath,
+        name: `${plan.name}.budget`,
+        lastOpenedAt: new Date().toISOString(),
+        planId: plan.id,
+        planName: plan.name,
+        planYear: plan.year,
+        sourceUri: result.uri,
+      });
+    } catch (err) {
+      Alert.alert(
+        'Could not save to folder',
+        err instanceof Error ? err.message : String(err),
+      );
     } finally {
-      setSharing(false);
+      setLinkingFolder(false);
     }
   }
 
@@ -313,13 +323,13 @@ export default function SettingsScreen() {
               onPress={() => router.push('/history')}
               style={{ marginBottom: spacing.sm }}
             />
-            {sourcePath && (
+            {sourcePath && !sourceUri && (
               <>
                 <Button
-                  title="Export / Back Up Plan…"
+                  title="Save to Folder…"
                   variant="secondary"
-                  onPress={sharePlanFile}
-                  loading={sharing}
+                  onPress={saveToFolder}
+                  loading={linkingFolder}
                   style={{ marginBottom: spacing.xs }}
                 />
                 <ThemedText
@@ -327,8 +337,9 @@ export default function SettingsScreen() {
                   size="xs"
                   style={{ marginBottom: spacing.sm }}
                 >
-                  Saved on this device automatically. Export to save a copy to Files, iCloud, or
-                  the desktop app.
+                  This plan only lives inside the app right now. Save it to a folder (Files, iCloud
+                  Drive…) to back it up and keep that file updated automatically — desktop can open
+                  it too.
                 </ThemedText>
               </>
             )}

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -40,7 +40,7 @@ const MODE_OPTIONS: { value: ThemeMode; label: string }[] = [
 ];
 
 export default function SettingsScreen() {
-  const { plan, sourcePath, encryptionKey, saveState, saveError, canUndo, canRedo, undo, redo, closePlan, changeEncryptionKey } =
+  const { plan, sourcePath, sourceUri, encryptionKey, saveState, saveError, syncState, syncError, canUndo, canRedo, undo, redo, closePlan, changeEncryptionKey } =
     usePlan();
   const { colors, spacing, radius, isDark, mode, preset, setMode, setPreset } = useTheme();
   const [sharing, setSharing] = useState(false);
@@ -168,9 +168,18 @@ export default function SettingsScreen() {
 
   const saveLabel =
     saveState === 'saving' ? 'Saving…'
-    : saveState === 'saved' ? 'All changes saved'
+    : saveState === 'saved' ?
+      (sourceUri && syncState === 'synced' ? 'All changes saved & synced to the original file'
+      : 'All changes saved')
     : saveState === 'error' ? `Save failed: ${saveError ?? 'unknown error'}`
     : sourcePath ? 'No changes yet' : 'Demo mode — changes are not saved';
+
+  // Saves always land in the on-device copy first; this only means the mirror
+  // write to the original document failed (e.g. access lapsed after a restart).
+  const syncWarning =
+    sourceUri && syncState === 'error'
+      ? `Saved on this device, but the original file could not be updated (${syncError ?? 'unknown error'}). Reopen the file with "Open Budget File" to reconnect it.`
+      : null;
 
   const version =
     Constants.expoConfig?.version ?? Constants.manifest2?.extra?.expoClient?.version ?? '—';
@@ -263,12 +272,20 @@ export default function SettingsScreen() {
               size="xs"
               style={{
                 marginTop: spacing.xs,
-                marginBottom: spacing.md,
+                marginBottom: syncWarning ? spacing.xs : spacing.md,
                 color: saveState === 'error' ? colors.error : undefined,
               }}
             >
               {saveLabel}
             </ThemedText>
+            {syncWarning && (
+              <ThemedText
+                size="xs"
+                style={{ marginBottom: spacing.md, color: colors.error }}
+              >
+                {syncWarning}
+              </ThemedText>
+            )}
 
             <View style={[styles.undoRow, { marginBottom: spacing.sm }]}>
               <Button

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -34,7 +34,6 @@
     "expo-router": "~6.0.0",
     "expo-secure-store": "~15.0.0",
     "expo-sensors": "~15.0.0",
-    "expo-sharing": "~14.0.0",
     "expo-splash-screen": "~0.30.0",
     "expo-status-bar": "~3.0.0",
     "lucide-react-native": "0.577.0",

--- a/apps/mobile/src/contexts/PlanContext.tsx
+++ b/apps/mobile/src/contexts/PlanContext.tsx
@@ -53,6 +53,8 @@ interface PlanContextValue {
   lastChange: ChangeSignal | null;
   setPlan: (plan: BudgetData | null, path: string | null, options?: SetPlanOptions) => void;
   updatePlan: (updater: (plan: BudgetData) => BudgetData, options?: UpdatePlanOptions) => void;
+  /** Link the open plan to a source document and sync it there immediately. */
+  attachSource: (uri: string) => void;
   /** Change the file's encryption: pass a key to encrypt, or null to decrypt. Re-writes the file. */
   changeEncryptionKey: (key: string | null) => void;
   undo: () => void;
@@ -228,6 +230,17 @@ export function PlanProvider({ children }: { children: ReactNode }) {
     applyPlan(next);
   }, [future, applyPlan]);
 
+  const attachSource = useCallback(
+    (uri: string) => {
+      if (!latest.current.plan || !latest.current.path) return;
+      latest.current = { ...latest.current, source: uri };
+      setSourceUri(uri);
+      // Sync right away so the new source document has the current plan state.
+      void flushSave();
+    },
+    [flushSave],
+  );
+
   const changeEncryptionKey = useCallback(
     (key: string | null) => {
       if (!latest.current.plan || !latest.current.path) return;
@@ -271,6 +284,7 @@ export function PlanProvider({ children }: { children: ReactNode }) {
         lastChange,
         setPlan,
         updatePlan,
+        attachSource,
         changeEncryptionKey,
         undo,
         redo,

--- a/apps/mobile/src/contexts/PlanContext.tsx
+++ b/apps/mobile/src/contexts/PlanContext.tsx
@@ -8,12 +8,21 @@ import {
   type ReactNode,
 } from 'react';
 import { buildAuditEntries, type BudgetData } from '@paycheck-planner/core';
-import { writePlanFile } from '../storage/planFileAdapter';
+import { writePlanFile, writePlanToSource } from '../storage/planFileAdapter';
 
 export type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 
+/** Status of mirroring saves back to the original (cloud) document. */
+export type SourceSyncState = 'idle' | 'synced' | 'error';
+
 interface SetPlanOptions {
   encryptionKey?: string | null;
+  /**
+   * The original document the plan was opened from (Files app / SAF provider).
+   * When set, every save is also written back to it so the source — e.g. a file
+   * in cloud storage — stays up to date, like editing in place on desktop.
+   */
+  sourceUri?: string | null;
 }
 
 export interface UpdatePlanOptions {
@@ -32,9 +41,13 @@ export interface ChangeSignal {
 interface PlanContextValue {
   plan: BudgetData | null;
   sourcePath: string | null;
+  /** Original document saves are mirrored back to, or null for local-only plans. */
+  sourceUri: string | null;
   encryptionKey: string | null;
   saveState: SaveState;
   saveError: string | null;
+  syncState: SourceSyncState;
+  syncError: string | null;
   canUndo: boolean;
   canRedo: boolean;
   lastChange: ChangeSignal | null;
@@ -55,18 +68,27 @@ const HISTORY_LIMIT = 50;
 export function PlanProvider({ children }: { children: ReactNode }) {
   const [plan, setPlanState] = useState<BudgetData | null>(null);
   const [sourcePath, setSourcePath] = useState<string | null>(null);
+  const [sourceUri, setSourceUri] = useState<string | null>(null);
   const [encryptionKey, setEncryptionKey] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [syncState, setSyncState] = useState<SourceSyncState>('idle');
+  const [syncError, setSyncError] = useState<string | null>(null);
   const [past, setPast] = useState<BudgetData[]>([]);
   const [future, setFuture] = useState<BudgetData[]>([]);
   const [lastChange, setLastChange] = useState<ChangeSignal | null>(null);
 
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const seqRef = useRef(0);
-  const latest = useRef<{ plan: BudgetData | null; path: string | null; key: string | null }>({
+  const latest = useRef<{
+    plan: BudgetData | null;
+    path: string | null;
+    source: string | null;
+    key: string | null;
+  }>({
     plan: null,
     path: null,
+    source: null,
     key: null,
   });
 
@@ -78,7 +100,7 @@ export function PlanProvider({ children }: { children: ReactNode }) {
   );
 
   const flushSave = useCallback(async () => {
-    const { plan: currentPlan, path, key } = latest.current;
+    const { plan: currentPlan, path, source, key } = latest.current;
     if (!currentPlan || !path) return;
 
     setSaveState('saving');
@@ -89,6 +111,20 @@ export function PlanProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       setSaveState('error');
       setSaveError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    // Mirror the save back to the document the plan was opened from so the
+    // source (e.g. a cloud-synced file) receives the edits too. Failure here
+    // never loses data — the durable on-device copy above already saved.
+    if (!source) return;
+    try {
+      await writePlanToSource(source, currentPlan, key);
+      setSyncState('synced');
+      setSyncError(null);
+    } catch (err) {
+      setSyncState('error');
+      setSyncError(err instanceof Error ? err.message : String(err));
     }
   }, []);
 
@@ -112,12 +148,20 @@ export function PlanProvider({ children }: { children: ReactNode }) {
   const setPlan = useCallback(
     (newPlan: BudgetData | null, path: string | null, options?: SetPlanOptions) => {
       if (saveTimer.current) clearTimeout(saveTimer.current);
-      latest.current = { plan: newPlan, path, key: options?.encryptionKey ?? null };
+      latest.current = {
+        plan: newPlan,
+        path,
+        source: options?.sourceUri ?? null,
+        key: options?.encryptionKey ?? null,
+      };
       setPlanState(newPlan);
       setSourcePath(path);
+      setSourceUri(options?.sourceUri ?? null);
       setEncryptionKey(options?.encryptionKey ?? null);
       setSaveState('idle');
       setSaveError(null);
+      setSyncState('idle');
+      setSyncError(null);
       setPast([]);
       setFuture([]);
       setLastChange(null);
@@ -197,12 +241,15 @@ export function PlanProvider({ children }: { children: ReactNode }) {
 
   const closePlan = useCallback(() => {
     if (saveTimer.current) clearTimeout(saveTimer.current);
-    latest.current = { plan: null, path: null, key: null };
+    latest.current = { plan: null, path: null, source: null, key: null };
     setPlanState(null);
     setSourcePath(null);
+    setSourceUri(null);
     setEncryptionKey(null);
     setSaveState('idle');
     setSaveError(null);
+    setSyncState('idle');
+    setSyncError(null);
     setPast([]);
     setFuture([]);
     setLastChange(null);
@@ -213,9 +260,12 @@ export function PlanProvider({ children }: { children: ReactNode }) {
       value={{
         plan,
         sourcePath,
+        sourceUri,
         encryptionKey,
         saveState,
         saveError,
+        syncState,
+        syncError,
         canUndo: past.length > 0,
         canRedo: future.length > 0,
         lastChange,

--- a/apps/mobile/src/hooks/usePlanFile.ts
+++ b/apps/mobile/src/hooks/usePlanFile.ts
@@ -24,7 +24,12 @@ export interface UsePlanFileResult {
 }
 
 export function usePlanFile(
-  onSuccess: (plan: BudgetData, uri: string, encryptionKey: string | null) => void,
+  onSuccess: (
+    plan: BudgetData,
+    uri: string,
+    encryptionKey: string | null,
+    sourceUri: string | null,
+  ) => void,
 ): UsePlanFileResult {
   const [status, setStatus] = useState<PlanLoadStatus>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -32,14 +37,18 @@ export function usePlanFile(
 
   const finalize = useCallback(
     async (plan: BudgetData, uri: string, name: string, encryptionKey: string | null) => {
-      // Keep a durable copy in the app's documents directory; picker copies
-      // land in the cache directory and can be evicted at any time.
+      // Keep a durable working copy in the app's documents directory, and hold
+      // on to the picked document itself so saves can be written back to it.
       let workingUri = uri;
       try {
         workingUri = await copyPlanIntoLibrary(uri, plan.id);
       } catch {
-        // Fall back to the original uri — read-only access still works.
+        // Fall back to editing the picked document directly.
       }
+      // When the library copy is the working file, the picked uri is the
+      // original document to sync saves back to; if the copy failed we already
+      // write straight to the document, so there is nothing extra to mirror.
+      const sourceUri = workingUri !== uri ? uri : null;
 
       await addRecentFile({
         uri: workingUri,
@@ -48,8 +57,9 @@ export function usePlanFile(
         planId: plan.id,
         planName: plan.name,
         planYear: plan.year,
+        ...(sourceUri ? { sourceUri } : {}),
       });
-      onSuccess(plan, workingUri, encryptionKey);
+      onSuccess(plan, workingUri, encryptionKey, sourceUri);
       setStatus('idle');
       setError(null);
     },
@@ -62,7 +72,10 @@ export function usePlanFile(
 
     const result = await DocumentPicker.getDocumentAsync({
       type: '*/*',
-      copyToCacheDirectory: true,
+      // Open the document in place (no cache copy) so we get the original
+      // file's uri and can write edits back to it — without this, edits only
+      // ever land in an app-local copy and never reach the source document.
+      copyToCacheDirectory: false,
       multiple: false,
     });
 

--- a/apps/mobile/src/storage/planFileAdapter.ts
+++ b/apps/mobile/src/storage/planFileAdapter.ts
@@ -1,5 +1,5 @@
 import * as FileSystem from 'expo-file-system/legacy';
-import { File } from 'expo-file-system';
+import { Directory, File } from 'expo-file-system';
 import CryptoJS from 'crypto-js';
 import type { BudgetData } from '@paycheck-planner/core';
 
@@ -160,19 +160,35 @@ function safeFileName(name: string): string {
   return cleaned || 'budget-plan';
 }
 
+export type FolderPlanFileResult =
+  | { status: 'created'; uri: string }
+  | { status: 'canceled' };
+
 /**
- * Make a temporary, human-readably named copy of the plan file for sharing, so
- * the export carries the plan's title (e.g. "2026 Plan.budget") instead of the
- * internal UUID filename — matching how the desktop app names saved files.
- * Returns the temp URI to hand to the share sheet.
+ * Ask the user to pick a folder — the Files app (incl. iCloud Drive) on iOS, a
+ * Storage Access Framework provider on Android — and create the plan's
+ * `.budget` document there, named after the plan like desktop does. The
+ * returned uri is the plan's source document: saves mirror to it from then on.
  */
-export async function createShareableCopy(sourceUri: string, plan: BudgetData): Promise<string> {
-  const targetUri = `${FileSystem.cacheDirectory}${safeFileName(plan.name)}.budget`;
-  try {
-    await FileSystem.deleteAsync(targetUri, { idempotent: true });
-  } catch {
-    // Ignore — target may not exist yet.
-  }
-  await FileSystem.copyAsync({ from: sourceUri, to: targetUri });
-  return targetUri;
+export async function createPlanFileInFolder(
+  plan: BudgetData,
+  encryptionKey?: string | null,
+): Promise<FolderPlanFileResult> {
+  const directory = await Directory.pickDirectoryAsync().catch((err: unknown) => {
+    if (isPickerCancellation(err)) return null;
+    throw err;
+  });
+  if (!directory) return { status: 'canceled' };
+
+  const file = directory.createFile(`${safeFileName(plan.name)}.budget`, 'application/json');
+  file.write(serializePlan(plan, encryptionKey));
+  return { status: 'created', uri: file.uri };
+}
+
+// Both platforms reject the directory-picker promise when the user backs out
+// (iOS FilePickingCancelledException / Android PickerCancelledException).
+function isPickerCancellation(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: string }).code ?? '';
+  return /cancel/i.test(`${code} ${err.message}`);
 }

--- a/apps/mobile/src/storage/planFileAdapter.ts
+++ b/apps/mobile/src/storage/planFileAdapter.ts
@@ -1,4 +1,5 @@
 import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import CryptoJS from 'crypto-js';
 import type { BudgetData } from '@paycheck-planner/core';
 
@@ -99,6 +100,23 @@ export async function writePlanFile(
   await FileSystem.writeAsStringAsync(uri, serializePlan(plan, encryptionKey), {
     encoding: FileSystem.EncodingType.UTF8,
   });
+}
+
+/**
+ * Write the plan back to the original document it was opened from, so edits
+ * reach the source (e.g. a file in iCloud Drive or Google Drive) instead of
+ * staying in the on-device copy — matching desktop, which saves in place.
+ *
+ * Uses the non-legacy `File` API: unlike the legacy one it can write to any
+ * provider's `content://` document on Android and to security-scoped files
+ * outside the sandbox on iOS.
+ */
+export async function writePlanToSource(
+  sourceUri: string,
+  plan: BudgetData,
+  encryptionKey?: string | null,
+): Promise<void> {
+  new File(sourceUri).write(serializePlan(plan, encryptionKey));
 }
 
 const PLAN_LIBRARY_DIR = 'plans/';

--- a/apps/mobile/src/storage/recentFilesStore.ts
+++ b/apps/mobile/src/storage/recentFilesStore.ts
@@ -10,6 +10,8 @@ export interface RecentFile {
   planId: string;
   planName?: string;
   planYear?: number;
+  /** Original picked document (cloud/provider URI) that saves are mirrored back to. */
+  sourceUri?: string;
 }
 
 export async function getRecentFiles(): Promise<RecentFile[]> {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.5.0",
   "description": "Monorepo workspace for Paycheck Planner apps and packages.",
   "type": "module",
-  "packageManager": "pnpm@11.6.0",
+  "packageManager": "pnpm@11.10.0",
   "engines": {
     "node": ">=22 <26",
     "pnpm": ">=10 <12"
@@ -48,6 +48,6 @@
     "test:run:desktop": "pnpm --config.minimumReleaseAge=0 turbo run test:run --filter=@paycheck-planner/desktop"
   },
   "devDependencies": {
-    "turbo": "^2.5.0"
+    "turbo": "^2.10.4"
   }
 }

--- a/patches/expo-document-picker@14.0.8.patch
+++ b/patches/expo-document-picker@14.0.8.patch
@@ -1,0 +1,72 @@
+diff --git a/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt b/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+--- a/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
++++ b/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+@@ -122,6 +122,7 @@
+     val originalDocumentDetails = DocumentDetailsReader(context).read(uri)
+ 
+     val details = if (!copyToCacheDirectory) {
++      takePersistableUriPermission(uri)
+       originalDocumentDetails
+     } else {
+       val copyPath = copyDocumentToCacheDirectory(uri, originalDocumentDetails.name)
+@@ -130,4 +131,21 @@
+ 
+     return details
+   }
++
++  // When the document is returned in place (no cache copy), persist the URI grant
++  // so the original document stays readable and writable across app restarts.
++  private fun takePersistableUriPermission(uri: Uri) {
++    try {
++      context.contentResolver.takePersistableUriPermission(
++        uri,
++        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
++      )
++    } catch (e: SecurityException) {
++      try {
++        context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
++      } catch (e: SecurityException) {
++        // The provider offered no persistable grant — in-session access still works.
++      }
++    }
++  }
+ }
+diff --git a/ios/DocumentPickerModule.swift b/ios/DocumentPickerModule.swift
+--- a/ios/DocumentPickerModule.swift
++++ b/ios/DocumentPickerModule.swift
+@@ -110,6 +110,14 @@
+   private func readDocumentDetails(documentUrl: URL, copy: Bool) throws -> DocumentInfo {
+     var newUrl = documentUrl
+ 
++    if !copy {
++      // The picker was presented in open-in-place mode, so the URL points at the
++      // original document outside the app sandbox. Start (and deliberately never
++      // stop) security-scoped access so the document stays readable and writable
++      // at its original location for the rest of the app session.
++      _ = documentUrl.startAccessingSecurityScopedResource()
++    }
++
+     guard let fileSystem = self.appContext?.fileSystem else {
+       throw Exceptions.FileSystemModuleNotFound()
+     }
+@@ -212,15 +220,18 @@
+   private func createDocumentPicker(with options: DocumentPickerOptions) -> UIDocumentPickerViewController {
+     if #available(iOS 14.0, *) {
+       let utTypes = options.type.compactMap { toUTType(mimeType: $0) }
++      // Open the document in place when the caller did not ask for a cache copy,
++      // so the returned (security-scoped) URL targets the original file and edits
++      // can be written back to it (e.g. documents in iCloud Drive).
+       return UIDocumentPickerViewController(
+         forOpeningContentTypes: utTypes,
+-        asCopy: true
++        asCopy: options.copyToCacheDirectory
+       )
+     } else {
+       let utiTypes = options.type.map { toUTI(mimeType: $0) }
+       return UIDocumentPickerViewController(
+         documentTypes: utiTypes,
+-        in: .import
++        in: options.copyToCacheDirectory ? .import : .open
+       )
+     }
+   }

--- a/patches/react-native-screens@4.16.0.patch
+++ b/patches/react-native-screens@4.16.0.patch
@@ -1,8 +1,40 @@
+diff --git a/ios/RNSScreenStackHeaderConfig.mm b/ios/RNSScreenStackHeaderConfig.mm
+--- a/ios/RNSScreenStackHeaderConfig.mm
++++ b/ios/RNSScreenStackHeaderConfig.mm
+@@ -608,12 +608,15 @@
+     }
+   }
+ 
+-  [navctr setNavigationBarHidden:shouldHide animated:animated];
+-
+   [config applySemanticContentAttributeIfNeededToNavCtrl:navctr];
+ 
+   if (shouldHide) {
+     navitem.title = config.title;
++
++    // Setting navigation bar visibility is split to mitigate iOS 26 bug with bar button items.
++    // Backported from react-native-screens 4.18+; without this, bar button items (including the
++    // back button) are unresponsive on iOS 26 when the bar is un-hidden before items are set.
++    [navctr setNavigationBarHidden:YES animated:animated];
+     return;
+   }
+ 
+@@ -749,6 +752,11 @@
+   // See: https://github.com/software-mansion/react-native-screens/issues/1570 (comments)
+   navitem.title = config.title;
+ 
++  // Setting navigation bar visibility is split to mitigate iOS 26 bug with bar button items
++  // (setting nav bar visibility should be done after the navigation item is configured).
++  // Backported from react-native-screens 4.18+.
++  [navctr setNavigationBarHidden:NO animated:animated];
++
+   if (animated && vc.transitionCoordinator != nil &&
+       vc.transitionCoordinator.presentationStyle == UIModalPresentationNone && !wasHidden) {
+     // when there is an ongoing transition we may need to update navbar setting in animation block
 diff --git a/src/components/ScreenStackHeaderConfig.tsx b/src/components/ScreenStackHeaderConfig.tsx
 --- a/src/components/ScreenStackHeaderConfig.tsx
 +++ b/src/components/ScreenStackHeaderConfig.tsx
-@@ -27,8 +27,7 @@ export const ScreenStackHeaderConfig = React.forwardRef<
-   <ScreenStackHeaderConfigNativeComponent
+@@ -29,8 +29,7 @@
      {...props}
      ref={ref}
      topInsetEnabled={EDGE_TO_EDGE ? true : props.topInsetEnabled}
@@ -11,3 +43,4 @@ diff --git a/src/components/ScreenStackHeaderConfig.tsx b/src/components/ScreenS
 +    style={[styles.headerConfig, { pointerEvents: 'box-none' }]}
    />
  ));
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
   '@react-navigation/bottom-tabs@7.16.2': 82072706e4e0aa5f40d91e40aa0efde4840f73a9c68e78118f019e10d0baa8f6
   '@react-navigation/elements@2.9.19': 4aa672296675827cfd107e47d76a769503474cd4f9593d367bee33499db9e928
   expo-document-picker@14.0.8: d82a8ef8fd2a7267fd6a72ab7ef5cda6e255d60190b125e64c8faa72c49f30dd
-  react-native-screens@4.16.0: 7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399
+  react-native-screens@4.16.0: fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0
 
 importers:
 
@@ -232,16 +232,13 @@ importers:
         version: 16.0.5(expo@54.0.35)
       expo-router:
         specifier: ~6.0.0
-        version: 6.0.24(37a3e68f20d6310ec8cfde2c96267590)
+        version: 6.0.24(9bf55591ea79a9e04d3bd064baf98cfe)
       expo-secure-store:
         specifier: ~15.0.0
         version: 15.0.8(expo@54.0.35)
       expo-sensors:
         specifier: ~15.0.0
         version: 15.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))
-      expo-sharing:
-        specifier: ~14.0.0
-        version: 14.0.8(expo@54.0.35)
       expo-splash-screen:
         specifier: ~0.30.0
         version: 0.30.10(expo@54.0.35)
@@ -274,7 +271,7 @@ importers:
         version: 5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       react-native-screens:
         specifier: 4.16.0
-        version: 4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
+        version: 4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       react-native-svg:
         specifier: 15.12.1
         version: 15.12.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
@@ -3736,11 +3733,6 @@ packages:
   expo-server@1.0.7:
     resolution: {integrity: sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==}
     engines: {node: '>=20.16.0'}
-
-  expo-sharing@14.0.8:
-    resolution: {integrity: sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q==}
-    peerDependencies:
-      expo: '*'
 
   expo-splash-screen@0.30.10:
     resolution: {integrity: sha512-Tt9va/sLENQDQYeOQ6cdLdGvTZ644KR3YG9aRlnpcs2/beYjOX1LHT510EGzVN9ljUTg+1ebEo5GGt2arYtPjw==}
@@ -7580,7 +7572,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.21.0
     optionalDependencies:
-      expo-router: 6.0.24(37a3e68f20d6310ec8cfde2c96267590)
+      expo-router: 6.0.24(9bf55591ea79a9e04d3bd064baf98cfe)
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -8522,7 +8514,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
 
-  '@react-navigation/bottom-tabs@7.16.2(patch_hash=82072706e4e0aa5f40d91e40aa0efde4840f73a9c68e78118f019e10d0baa8f6)(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)':
+  '@react-navigation/bottom-tabs@7.16.2(patch_hash=82072706e4e0aa5f40d91e40aa0efde4840f73a9c68e78118f019e10d0baa8f6)(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/elements': 2.9.19(patch_hash=4aa672296675827cfd107e47d76a769503474cd4f9593d367bee33499db9e928)(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native': 7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
@@ -8530,7 +8522,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
       react-native-safe-area-context: 5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
-      react-native-screens: 4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -8557,7 +8549,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
 
-  '@react-navigation/native-stack@7.16.0(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)':
+  '@react-navigation/native-stack@7.16.0(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@react-navigation/elements': 2.9.19(patch_hash=4aa672296675827cfd107e47d76a769503474cd4f9593d367bee33499db9e928)(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native': 7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
@@ -8565,7 +8557,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
       react-native-safe-area-context: 5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
-      react-native-screens: 4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -10317,15 +10309,15 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
 
-  expo-router@6.0.24(37a3e68f20d6310ec8cfde2c96267590):
+  expo-router@6.0.24(9bf55591ea79a9e04d3bd064baf98cfe):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.35)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
       '@radix-ui/react-slot': 1.2.0(@types/react@19.2.15)(react@19.1.0)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-navigation/bottom-tabs': 7.16.2(patch_hash=82072706e4e0aa5f40d91e40aa0efde4840f73a9c68e78118f019e10d0baa8f6)(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.16.2(patch_hash=82072706e4e0aa5f40d91e40aa0efde4840f73a9c68e78118f019e10d0baa8f6)(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native': 7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
-      '@react-navigation/native-stack': 7.16.0(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native-stack': 7.16.0(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
@@ -10342,7 +10334,7 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       react-native-safe-area-context: 5.4.0(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
-      react-native-screens: 4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
@@ -10371,10 +10363,6 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
 
   expo-server@1.0.7: {}
-
-  expo-sharing@14.0.8(expo@54.0.35):
-    dependencies:
-      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-splash-screen@0.30.10(expo@54.0.35):
     dependencies:
@@ -12383,7 +12371,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0)
 
-  react-native-screens@4.16.0(patch_hash=7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0):
+  react-native-screens@4.16.0(patch_hash=fea6568dd0c97994439f7afd61716e778d1d7a7774657429ffbcbf99a3f9b2b0)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-freeze: 1.0.4(react@19.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
 patchedDependencies:
   '@react-navigation/bottom-tabs@7.16.2': 82072706e4e0aa5f40d91e40aa0efde4840f73a9c68e78118f019e10d0baa8f6
   '@react-navigation/elements@2.9.19': 4aa672296675827cfd107e47d76a769503474cd4f9593d367bee33499db9e928
+  expo-document-picker@14.0.8: d82a8ef8fd2a7267fd6a72ab7ef5cda6e255d60190b125e64c8faa72c49f30dd
   react-native-screens@4.16.0: 7fb636fa88619e997f238f0c72109162423963119c12ce39216ab875a1393399
 
 importers:
@@ -213,7 +214,7 @@ importers:
         version: 6.0.21(expo@54.0.35)
       expo-document-picker:
         specifier: ~14.0.0
-        version: 14.0.8(expo@54.0.35)
+        version: 14.0.8(patch_hash=d82a8ef8fd2a7267fd6a72ab7ef5cda6e255d60190b125e64c8faa72c49f30dd)(expo@54.0.35)
       expo-file-system:
         specifier: ~19.0.0
         version: 19.0.23(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))
@@ -10250,7 +10251,7 @@ snapshots:
       expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-dev-menu-interface: 2.0.0(expo@54.0.35)
 
-  expo-document-picker@14.0.8(expo@54.0.35):
+  expo-document-picker@14.0.8(patch_hash=d82a8ef8fd2a7267fd6a72ab7ef5cda6e255d60190b125e64c8faa72c49f30dd)(expo@54.0.35):
     dependencies:
       expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
   .:
     devDependencies:
       turbo:
-        specifier: ^2.5.0
-        version: 2.9.16
+        specifier: ^2.10.4
+        version: 2.10.4
 
   apps/api:
     dependencies:
@@ -2390,33 +2390,33 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@turbo/darwin-64@2.9.16':
-    resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
+  '@turbo/darwin-64@2.10.4':
+    resolution: {integrity: sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.16':
-    resolution: {integrity: sha512-YPgrn+5HIGzrx0O2a631SV4MBQUe4W/DafMFUuBVgaU32PW9/OTT0ehviF0QSxTXuRJlHvW2eUTemddF5/spmw==}
+  '@turbo/darwin-arm64@2.10.4':
+    resolution: {integrity: sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.16':
-    resolution: {integrity: sha512-vAEf1H6l26lTpl9FJ/peQo1NUB8RC0sbEJJz5mPcUhHA2bPDup2x3CZPgo/bH8S4cUcBLm4FN3UHd5iUO2RAew==}
+  '@turbo/linux-64@2.10.4':
+    resolution: {integrity: sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.16':
-    resolution: {integrity: sha512-xDBLR2PZg4BrQOchfG6svgpv5FCNJ2TOtT2psLdEJcdKo1BH+pnPs9Xj6pvUjgfkHbuvBOfeE4R6tvxMoQKDHQ==}
+  '@turbo/linux-arm64@2.10.4':
+    resolution: {integrity: sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.16':
-    resolution: {integrity: sha512-NBAJnaUiGdgkSzQwUIdOvkCkcpTSu58G/sBGa0mvBtzfvFOOgrQwepKOOQ8cp6sWM6OcKDNFj2p1dsZA1OWjPg==}
+  '@turbo/windows-64@2.10.4':
+    resolution: {integrity: sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.16':
-    resolution: {integrity: sha512-Y7SJppD0Z8wjO3Ec0ZGd9KQ4Yv0BMnA8CIowj5Vp+OEVsosXDG2weK6/t1RRLfJmc2Ozrnd6y4DOgQys+mn3WQ==}
+  '@turbo/windows-arm64@2.10.4':
+    resolution: {integrity: sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA==}
     cpu: [arm64]
     os: [win32]
 
@@ -6006,8 +6006,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.9.16:
-    resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
+  turbo@2.10.4:
+    resolution: {integrity: sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -8708,22 +8708,22 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@turbo/darwin-64@2.9.16':
+  '@turbo/darwin-64@2.10.4':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.16':
+  '@turbo/darwin-arm64@2.10.4':
     optional: true
 
-  '@turbo/linux-64@2.9.16':
+  '@turbo/linux-64@2.10.4':
     optional: true
 
-  '@turbo/linux-arm64@2.9.16':
+  '@turbo/linux-arm64@2.10.4':
     optional: true
 
-  '@turbo/windows-64@2.9.16':
+  '@turbo/windows-64@2.10.4':
     optional: true
 
-  '@turbo/windows-arm64@2.9.16':
+  '@turbo/windows-arm64@2.10.4':
     optional: true
 
   '@types/aria-query@5.0.4': {}
@@ -13087,14 +13087,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.9.16:
+  turbo@2.10.4:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.16
-      '@turbo/darwin-arm64': 2.9.16
-      '@turbo/linux-64': 2.9.16
-      '@turbo/linux-arm64': 2.9.16
-      '@turbo/windows-64': 2.9.16
-      '@turbo/windows-arm64': 2.9.16
+      '@turbo/darwin-64': 2.10.4
+      '@turbo/darwin-arm64': 2.10.4
+      '@turbo/linux-64': 2.10.4
+      '@turbo/linux-arm64': 2.10.4
+      '@turbo/windows-64': 2.10.4
+      '@turbo/windows-arm64': 2.10.4
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,4 +18,5 @@ allowBuilds:
 patchedDependencies:
   '@react-navigation/bottom-tabs@7.16.2': patches/@react-navigation__bottom-tabs@7.16.2.patch
   '@react-navigation/elements@2.9.19': patches/@react-navigation__elements@2.9.19.patch
+  expo-document-picker@14.0.8: patches/expo-document-picker@14.0.8.patch
   react-native-screens@4.16.0: patches/react-native-screens@4.16.0.patch

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://v2-10-4.turborepo.dev/schema.json",
   "ui": "tui",
   "tasks": {
     "dev": {


### PR DESCRIPTION
On mobile, opening a plan made an app-local copy and every save went only to that copy, so the original document — e.g. a file in iCloud Drive or Google Drive — never received edits (unlike desktop, which saves in place). Root cause: expo-document-picker always imports a temporary copy on iOS (asCopy: true) and the app never kept the picked document's uri.

- Patch expo-document-picker so copyToCacheDirectory: false opens the document in place: iOS returns the original security-scoped URL and keeps access for the session; Android takes a persistable read/write grant on the SAF uri so access survives restarts.
- Pick with copyToCacheDirectory: false and track the source uri through usePlanFile, PlanContext, and recent files.
- Mirror every save back to the source document via the non-legacy expo-file-system File API (writes any provider's content:// document on Android and security-scoped files on iOS); the durable on-device copy still saves first so a failed mirror never loses data.
- Reopening from Recent Files reads the source document when reachable (picking up desktop-side changes) and refreshes the on-device copy.
- Settings now shows sync status and a recovery hint when the original file can't be updated (e.g. access lapsed after an iOS restart).


Claude-Session: https://claude.ai/code/session_013AXoNCk8KUv3uZpRWPxfZr